### PR TITLE
Add skeleton data analysis app with voice input

### DIFF
--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -1,0 +1,62 @@
+from langchain.llms import Ollama
+from langchain.agents import initialize_agent, Tool
+from langchain.prompts import PromptTemplate
+from langchain.agents import AgentType
+from langchain.tools import tool
+import pandas as pd
+from typing import Dict, Any
+
+
+def create_agent(df: pd.DataFrame):
+    llm = Ollama(model="llama3")
+
+    @tool
+    def display_dataframe(head: int = 5) -> str:
+        """Display the first few rows of the dataframe"""
+        return df.head(head).to_markdown()
+
+    @tool
+    def show_data_summary() -> str:
+        """Show number of rows, columns and missing values"""
+        missing = df.isnull().sum().sum()
+        return f"Rows: {len(df)}, Columns: {len(df.columns)}, Missing: {missing}"
+
+    @tool
+    def show_descriptive_stats() -> str:
+        """Show descriptive statistics"""
+        return df.describe().to_markdown()
+
+    @tool
+    def show_correlation_matrix() -> str:
+        """Compute correlation matrix"""
+        return df.corr().to_markdown()
+
+    @tool
+    def plot_histogram(column_name: str) -> str:
+        """Return histogram data for a column"""
+        hist = df[column_name].dropna().hist().get_figure()
+        hist_data = hist.to_json()
+        return hist_data
+
+    @tool
+    def plot_scatterplot(x_column: str, y_column: str) -> str:
+        """Return scatterplot data for two columns"""
+        fig = df.plot.scatter(x=x_column, y=y_column).get_figure()
+        plot_data = fig.to_json()
+        return plot_data
+
+    tools = [
+        Tool(name="display_dataframe", func=display_dataframe, description="Display part of the dataframe"),
+        Tool(name="show_data_summary", func=show_data_summary, description="Show summary of the data"),
+        Tool(name="show_descriptive_stats", func=show_descriptive_stats, description="Show descriptive statistics"),
+        Tool(name="show_correlation_matrix", func=show_correlation_matrix, description="Compute correlation matrix"),
+        Tool(name="plot_histogram", func=plot_histogram, description="Plot histogram for a column"),
+        Tool(name="plot_scatterplot", func=plot_scatterplot, description="Plot scatterplot for two columns"),
+    ]
+
+    prompt = PromptTemplate.from_template(
+        """You are a data analysis assistant. Use the provided tools to answer the user's questions about the data."""
+    )
+
+    agent = initialize_agent(tools, llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=False, prompt=prompt)
+    return agent

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,68 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import JSONResponse
+import pandas as pd
+from typing import Dict
+from .agent import create_agent
+from xinference import Client
+import tempfile
+
+app = FastAPI()
+
+sessions: Dict[str, pd.DataFrame] = {}
+agents: Dict[str, any] = {}
+
+xinference_client = Client("http://localhost:9997")  # adjust if needed
+model_uid = None
+
+@app.on_event("startup")
+async def startup_event():
+    global model_uid
+    try:
+        model_uid = xinference_client.launch_model(model_name="whisper", model_size="small")
+    except Exception:
+        # assume already launched
+        models = xinference_client.list_models()
+        for uid, info in models.items():
+            if info.get("model_name") == "whisper":
+                model_uid = uid
+                break
+
+@app.post("/api/upload")
+async def upload_csv(session_id: str = Form(...), file: UploadFile = File(...)):
+    try:
+        df = pd.read_csv(file.file)
+        sessions[session_id] = df
+        agents[session_id] = create_agent(df)
+        return {"status": "success", "columns": df.columns.tolist()}
+    except Exception as e:
+        return JSONResponse(status_code=400, content={"status": "error", "detail": str(e)})
+
+@app.post("/api/chat")
+async def chat(session_id: str = Form(...), message: str = Form(...)):
+    if session_id not in sessions:
+        return JSONResponse(status_code=404, content={"status": "error", "detail": "Session not found"})
+    try:
+        agent = agents[session_id]
+        reply = agent.run(message)
+        return {"status": "success", "reply": reply}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"status": "error", "detail": str(e)})
+
+@app.post("/api/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    if model_uid is None:
+        return JSONResponse(status_code=500, content={"status": "error", "detail": "Model not ready"})
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            content = await file.read()
+            tmp.write(content)
+            tmp.flush()
+            resp = xinference_client.chat(model_uid, input=tmp.name)
+        text = resp["text"] if isinstance(resp, dict) else resp
+        return {"status": "success", "text": text}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"status": "error", "detail": str(e)})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+pandas
+python-multipart
+langchain
+langchain-community
+ollama
+xinference-client

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chatalysis</title>
+  <script type="module" src="/src/main.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="app"></div>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "chatalysis-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.3.4",
+    "axios": "^1.4.0",
+    "plotly.js-dist": "^2.27.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^4.0.0",
+    "vite": "^4.3.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="container mx-auto p-4">
+    <UploadArea :sessionId="sessionId" @uploaded="handleUploaded" />
+    <ChatWindow :messages="messages" @send="sendMessage" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import UploadArea from './components/UploadArea.vue'
+import ChatWindow from './components/ChatWindow.vue'
+import axios from 'axios'
+
+const messages = ref([])
+const sessionId = Math.random().toString(36).substring(2)
+
+const handleUploaded = (cols) => {
+  messages.value.push({ sender: 'system', text: `Uploaded CSV with columns: ${cols.join(', ')}` })
+}
+
+const sendMessage = async (text) => {
+  messages.value.push({ sender: 'user', text })
+  const form = new FormData()
+  form.append('session_id', sessionId)
+  form.append('message', text)
+  const res = await axios.post('/api/chat', form)
+  messages.value.push({ sender: 'bot', text: res.data.reply })
+}
+</script>

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <div class="border p-2 h-96 overflow-y-auto mb-2" ref="chatArea">
+      <div v-for="(m, i) in messages" :key="i" class="mb-1">
+        <strong>{{ m.sender }}:</strong> {{ m.text }}
+      </div>
+    </div>
+    <div class="flex items-center">
+      <input v-model="input" @keyup.enter="emitSend" class="flex-1 border p-2" />
+      <button @mousedown="startRecording" @mouseup="stopRecording" class="ml-2 px-2 py-2 bg-gray-300">🎤</button>
+      <button @click="emitSend" class="ml-2 px-4 py-2 bg-blue-500 text-white">Send</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import axios from 'axios'
+const props = defineProps({ messages: Array })
+const emit = defineEmits(['send'])
+const input = ref('')
+const chatArea = ref(null)
+let mediaRecorder
+let chunks = []
+
+const emitSend = () => {
+  if (!input.value) return
+  emit('send', input.value)
+  input.value = ''
+}
+
+const startRecording = async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  mediaRecorder = new MediaRecorder(stream)
+  mediaRecorder.ondataavailable = e => chunks.push(e.data)
+  mediaRecorder.onstop = async () => {
+    const blob = new Blob(chunks, { type: 'audio/webm' })
+    chunks = []
+    const form = new FormData()
+    form.append('file', blob, 'recording.webm')
+    const res = await axios.post('/api/transcribe', form)
+    input.value = res.data.text
+  }
+  mediaRecorder.start()
+}
+
+const stopRecording = () => {
+  if (mediaRecorder) mediaRecorder.stop()
+}
+
+watch(() => props.messages.length, () => {
+  chatArea.value.scrollTop = chatArea.value.scrollHeight
+})
+</script>

--- a/frontend/src/components/UploadArea.vue
+++ b/frontend/src/components/UploadArea.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="mb-4">
+    <input type="file" @change="onFileChange" />
+  </div>
+</template>
+
+<script setup>
+import axios from 'axios'
+const props = defineProps({ sessionId: String })
+const emit = defineEmits(['uploaded'])
+
+const onFileChange = async (e) => {
+  const file = e.target.files[0]
+  if (!file) return
+  const form = new FormData()
+  form.append('session_id', props.sessionId)
+  form.append('file', file)
+  const res = await axios.post('/api/upload', form)
+  emit('uploaded', res.data.columns)
+}
+</script>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './index.css'
+
+createApp(App).mount('#app')

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- set up backend and frontend folders
- add FastAPI backend with CSV upload, chat, and voice transcription using Xinference
- define LangChain agent using Ollama and pandas tools
- scaffold Vue 3 frontend with Tailwind and chat UI
- implement microphone recording that sends audio for transcription

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68522508f9b883288ba7daf21e750de2