### PR TITLE
Fix backend execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install dependencies with [uv](https://github.com/astral-sh/uv) and start the ba
 
 ```bash
 uv pip install -r backend/requirements.txt
-uvicorn app.main:app --host 0.0.0.0 --port 8000
+uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
 ```
 
 In a separate terminal start the frontend:

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'app' a package


### PR DESCRIPTION
## Summary
- make `app` a proper Python package
- update README instructions to use `backend.app.main`

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68523a9266b88328938800935b838744