### PR TITLE
Refactor modules

### DIFF
--- a/exec_cache.py
+++ b/exec_cache.py
@@ -1,0 +1,35 @@
+import hashlib
+import io
+import pandas as pd
+import matplotlib.pyplot as plt
+import streamlit as st
+
+if "exec_cache" not in st.session_state:
+    st.session_state.exec_cache = {}
+
+def run_code_once(code: str, show: bool = True) -> list[bytes]:
+    code_hash = hashlib.md5(code.encode("utf-8")).hexdigest()
+    cache = st.session_state.exec_cache.get(code_hash)
+
+    if cache:
+        if show:
+            for buf in cache["fig_bytes"]:
+                st.image(buf, use_column_width=True)
+        return cache["fig_bytes"]
+
+    local_ctx = {"df": st.session_state.df, "pd": pd, "st": st, "plt": plt}
+    exec(code, {}, local_ctx)
+
+    fig_bytes: list[bytes] = []
+    for num in plt.get_fignums():
+        fig = plt.figure(num)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", bbox_inches="tight")
+        buf.seek(0)
+        fig_bytes.append(buf.getvalue())
+        if show:
+            st.pyplot(fig, clear_figure=True)
+        plt.close(fig)
+
+    st.session_state.exec_cache[code_hash] = {"fig_bytes": fig_bytes}
+    return fig_bytes

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,0 +1,29 @@
+import os
+import requests
+import streamlit as st
+from dotenv import load_dotenv
+from langchain.llms import Ollama
+
+load_dotenv()
+WHISPER_URL = os.getenv("WHISPER_URL", "http://localhost:8000/v1/audio/transcriptions")
+
+@st.cache_resource(show_spinner="LLM をロード中…")
+def load_llm():
+    return Ollama(
+        model=os.getenv("OLLAMA_MODEL", "qwen3:14b"),
+        base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+        temperature=0.7,
+        top_p=0.95,
+        top_k=20,
+    )
+
+def whisper_transcribe(audio_bytes: bytes, mime: str = "audio/webm", lang: str = "ja") -> str:
+    files = {"file": ("audio.webm", audio_bytes, mime)}
+    data = {"model": os.getenv("WHISPER_MODEL", "whisper-1"), "language": lang}
+    try:
+        r = requests.post(WHISPER_URL, files=files, data=data, timeout=90)
+        r.raise_for_status()
+        return r.json().get("text", "").strip()
+    except Exception as e:
+        st.error(f"Whisper API エラー: {e}")
+        return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-py-modules = ["app", "main"]
+py-modules = ["app", "main", "llm_utils", "exec_cache"]


### PR DESCRIPTION
## Summary
- move LLM functions to `llm_utils.py`
- move code execution cache to `exec_cache.py`
- update `app.py` to use the new modules
- declare new modules in `pyproject.toml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857d281bea08328afd6ae4e5719afd3